### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -228,6 +228,8 @@ jobs:
   trigger-harness-deployment:
     name: Trigger Harness CD Pipeline
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build-database-artifact, build-app-image]
     if: success()
 


### PR DESCRIPTION
Potential fix for [https://github.com/liquibase-examples/gha-cd-bagelstore-demo/security/code-scanning/2](https://github.com/liquibase-examples/gha-cd-bagelstore-demo/security/code-scanning/2)

In general, fix this by adding an explicit `permissions` block to the job (or workflow root) that grants only the minimal required scopes, instead of relying on inherited defaults. For this specific job, it only needs to read repository content/metadata, so `contents: read` is sufficient. It does not push code, modify issues/PRs, or interact with GitHub Packages, so no write permissions are needed.

The best minimal fix without changing functionality is to modify `.github/workflows/main-ci.yml` under the `trigger-harness-deployment` job definition and add a `permissions` section with `contents: read`. Concretely, after line 231 (`runs-on: ubuntu-latest`) we introduce:

```yaml
    permissions:
      contents: read
```

This keeps the existing behavior intact while documenting and enforcing least-privilege access for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
