### PR TITLE
Add manual rollback capability to Harness CD pipeline

### DIFF
--- a/.harness/orgs/default/projects/bagel_store_demo/pipelines/Deploy_Bagel_Store/input_sets/webhook_default.yaml
+++ b/.harness/orgs/default/projects/bagel_store_demo/pipelines/Deploy_Bagel_Store/input_sets/webhook_default.yaml
@@ -15,3 +15,9 @@ inputSet:
       - name: DEPLOYMENT_TARGET
         type: String
         value: <+trigger.payload.deployment_target>
+      - name: ROLLBACK
+        type: String
+        value: "false"
+      - name: ROLLBACK_TO_VERSION
+        type: String
+        value: ""

--- a/.harness/orgs/default/projects/bagel_store_demo/templates/Coordinated_DB_App_Deployment/v1_0.yaml
+++ b/.harness/orgs/default/projects/bagel_store_demo/templates/Coordinated_DB_App_Deployment/v1_0.yaml
@@ -11,19 +11,27 @@ template:
   description: |
     Reusable step group for deploying database changes and application updates.
     Supports both AWS (RDS + App Runner) and Local (Docker Compose) deployment modes.
+    Supports manual rollback via ROLLBACK pipeline variable.
 
-    Steps:
+    Forward Deploy Steps (ROLLBACK != "true"):
     1. Fetch Changelog Artifact - Downloads changelog zip from GitHub Actions artifacts
     2. Update Database - Runs Liquibase update via Docker container
     3. Deploy Application - Updates App Runner (AWS) or Docker Compose (local) via deployment script
     4. Health Check - Verifies deployment success with version check
     5. Fetch Instances - Reports instance information to Harness for tracking
 
+    Rollback Steps (ROLLBACK == "true"):
+    6. Fetch Changelog Artifact (Rollback) - Downloads changelog for rollback target version
+    7. Rollback Application - Reverts App Runner/Docker Compose to previous version (app first)
+    8. Rollback Database - Runs Liquibase rollback to target version tag (DB second)
+    9. Rollback Health Check - Verifies rollback success
+
     Architecture:
     - Uses external deployment scripts (bind mounted to delegate from harness/scripts/)
     - Scripts update automatically on git push (no UI refresh needed)
     - For AWS: Calls aws apprunner update-service directly (no Terraform)
     - For local: Updates Docker Compose with new version
+    - Rollback ordering: Application first, then database (avoids new code against old schema)
 
     Environment variables used (automatically resolved from stage context):
     - env.variables.environment: Target environment (dev/test/staging/prod)
@@ -43,12 +51,16 @@ template:
     Pipeline variables used:
     - pipeline.variables.VERSION: Git tag version to deploy
     - pipeline.variables.GITHUB_ORG: GitHub organization name
+    - pipeline.variables.ROLLBACK: "true" to rollback, "false" (default) to deploy
+    - pipeline.variables.ROLLBACK_TO_VERSION: Target version for rollback
 
     Deployment mode controlled by:
     - DEPLOYMENT_TARGET environment variable: "aws" (default) or "local"
 
   spec:
     steps:
+      # ===== FORWARD DEPLOY STEPS (skipped during rollback) =====
+
       # Step 1: Fetch changelog artifact from GitHub Actions
       - step:
           type: ShellScript
@@ -68,6 +80,9 @@ template:
             environmentVariables: []
             outputVariables: []
           timeout: 5m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> != "true"
 
       # Step 2: Update database with Liquibase
       - step:
@@ -111,6 +126,9 @@ template:
             environmentVariables: []
             outputVariables: []
           timeout: 10m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> != "true"
 
       # Step 3: Deploy application
       - step:
@@ -157,6 +175,9 @@ template:
             environmentVariables: []
             outputVariables: []
           timeout: 10m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> != "true"
 
       # Step 4: Health check
       - step:
@@ -178,6 +199,9 @@ template:
             environmentVariables: []
             outputVariables: []
           timeout: 10m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> != "true"
 
       # Step 5: Fetch Instance Script (required for CustomDeployment tracking)
       - step:
@@ -198,5 +222,147 @@ template:
             outputVariables: []
             environmentVariables: []
           timeout: 5m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> != "true"
+
+      # ===== ROLLBACK STEPS (skipped during normal deploy) =====
+
+      # Step 6: Fetch changelog artifact for rollback target version
+      - step:
+          type: ShellScript
+          name: Fetch Changelog Artifact (Rollback)
+          identifier: Fetch_Changelog_Artifact_Rollback
+          spec:
+            shell: Bash
+            executionTarget: {}
+            source:
+              type: Inline
+              spec:
+                script: |-
+                  /opt/harness-delegate/scripts/fetch-changelog-artifact.sh \
+                    "<+pipeline.variables.ROLLBACK_TO_VERSION>" \
+                    "<+pipeline.variables.GITHUB_ORG>" \
+                    "<+secrets.getValue('github_pat')>"
+            environmentVariables: []
+            outputVariables: []
+          timeout: 5m
+          when:
+            stageStatus: Success
+            condition: <+pipeline.variables.ROLLBACK> == "true"
+
+      # Step 7: Rollback application (app first - avoid new code against old schema)
+      - step:
+          type: ShellScript
+          name: Rollback Application
+          identifier: Rollback_Application
+          spec:
+            shell: Bash
+            executionTarget: {}
+            source:
+              type: Inline
+              spec:
+                script: |-
+                  # Build AWS parameters JSON
+                  AWS_PARAMS=$(cat <<'EOF'
+                  {
+                    "app_runner_service_arn": "<+env.variables.app_runner_service_arn>",
+                    "aws_region": "<+env.variables.aws_region>",
+                    "demo_id": "<+env.variables.demo_id>",
+                    "rds_address": "<+env.variables.rds_address>",
+                    "rds_port": "<+env.variables.rds_port>",
+                    "database_name": "<+env.variables.database_name>",
+                    "secrets_username_arn": "<+env.variables.secrets_username_arn>",
+                    "secrets_password_arn": "<+env.variables.secrets_password_arn>",
+                    "ecr_public_alias": "<+env.variables.ecr_public_alias>"
+                  }
+                  EOF
+                  )
+
+                  # Build secrets JSON
+                  SECRETS=$(cat <<'EOF'
+                  {}
+                  EOF
+                  )
+
+                  /opt/harness-delegate/scripts/rollback-application.sh \
+                    "<+env.variables.environment>" \
+                    "<+pipeline.variables.ROLLBACK_TO_VERSION>" \
+                    "<+pipeline.variables.GITHUB_ORG>" \
+                    "${DEPLOYMENT_TARGET:-aws}" \
+                    "$AWS_PARAMS" \
+                    "$SECRETS"
+            environmentVariables: []
+            outputVariables: []
+          timeout: 10m
+          when:
+            condition: <+pipeline.variables.ROLLBACK> == "true"
+
+      # Step 8: Rollback database (after app, so old code runs against current schema first)
+      - step:
+          type: ShellScript
+          name: Rollback Database
+          identifier: Rollback_Database
+          spec:
+            shell: Bash
+            executionTarget: {}
+            source:
+              type: Inline
+              spec:
+                script: |-
+                  # Build AWS parameters JSON
+                  AWS_PARAMS=$(cat <<'EOF'
+                  {
+                    "jdbc_url": "<+env.variables.jdbc_url>",
+                    "aws_region": "<+env.variables.aws_region>",
+                    "liquibase_flows_bucket": "<+env.variables.liquibase_flows_bucket>",
+                    "rds_endpoint": "<+env.variables.rds_endpoint>"
+                  }
+                  EOF
+                  )
+
+                  # Build secrets JSON
+                  SECRETS=$(cat <<'EOF'
+                  {
+                    "liquibase_license_key": "<+secrets.getValue('liquibase_license_key')>"
+                  }
+                  EOF
+                  )
+
+                  /opt/harness-delegate/scripts/rollback-database.sh \
+                    "<+env.variables.environment>" \
+                    "<+env.variables.demo_id>" \
+                    "${DEPLOYMENT_TARGET:-aws}" \
+                    "$AWS_PARAMS" \
+                    "$SECRETS" \
+                    "<+pipeline.variables.ROLLBACK_TO_VERSION>"
+            environmentVariables: []
+            outputVariables: []
+          timeout: 10m
+          when:
+            condition: <+pipeline.variables.ROLLBACK> == "true"
+
+      # Step 9: Health check after rollback
+      - step:
+          type: ShellScript
+          name: Rollback Health Check
+          identifier: Rollback_Health_Check
+          spec:
+            shell: Bash
+            executionTarget: {}
+            source:
+              type: Inline
+              spec:
+                script: |-
+                  /opt/harness-delegate/scripts/health-check.sh \
+                    "<+env.variables.environment>" \
+                    "<+pipeline.variables.ROLLBACK_TO_VERSION>" \
+                    "${DEPLOYMENT_TARGET:-aws}" \
+                    "<+env.variables.app_runner_service_url>"
+            environmentVariables: []
+            outputVariables: []
+          timeout: 10m
+          when:
+            condition: <+pipeline.variables.ROLLBACK> == "true"
 
     stageType: Deployment

--- a/demo-dashboard.html
+++ b/demo-dashboard.html
@@ -174,6 +174,137 @@
         </header>
 
         <div class="grid">
+            <!-- Architecture Diagram -->
+            <div class="card full-width">
+                <h2><span class="icon">🏗️</span> Application Architecture</h2>
+                <svg viewBox="0 0 920 320" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:auto;display:block">
+                    <defs>
+                        <filter id="cardShadow" x="-5%" y="-5%" width="115%" height="130%">
+                            <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#00000012"/>
+                        </filter>
+                        <marker id="arr" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+                            <polygon points="0 0, 7 2.5, 0 5" fill="#94a3b8"/>
+                        </marker>
+                        <style>
+                            .app-link { cursor: pointer; }
+                            .app-link .hover-overlay { fill: transparent; transition: fill 0.15s; }
+                            .app-link:hover .hover-overlay { fill: rgba(0,0,0,0.045); }
+                        </style>
+                        <!-- Left-border gradients for each environment -->
+                        <linearGradient id="gradDev" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0"     stop-color="#10b981"/>
+                            <stop offset="0.023" stop-color="#10b981"/>
+                            <stop offset="0.023" stop-color="white"/>
+                            <stop offset="1"     stop-color="white"/>
+                        </linearGradient>
+                        <linearGradient id="gradTest" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0"     stop-color="#3b82f6"/>
+                            <stop offset="0.023" stop-color="#3b82f6"/>
+                            <stop offset="0.023" stop-color="white"/>
+                            <stop offset="1"     stop-color="white"/>
+                        </linearGradient>
+                        <linearGradient id="gradStaging" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0"     stop-color="#f59e0b"/>
+                            <stop offset="0.023" stop-color="#f59e0b"/>
+                            <stop offset="0.023" stop-color="white"/>
+                            <stop offset="1"     stop-color="white"/>
+                        </linearGradient>
+                        <linearGradient id="gradProd" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0"     stop-color="#ef4444"/>
+                            <stop offset="0.023" stop-color="#ef4444"/>
+                            <stop offset="0.023" stop-color="white"/>
+                            <stop offset="1"     stop-color="white"/>
+                        </linearGradient>
+                    </defs>
+
+                    <!-- Background -->
+                    <rect width="920" height="320" fill="#f8fafc" rx="10"/>
+                    <!-- AWS boundary -->
+                    <rect x="12" y="12" width="896" height="296" rx="10" fill="none" stroke="#e2e8f0" stroke-width="1.5" stroke-dasharray="5,4"/>
+                    <text x="24" y="28" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" fill="#94a3b8" font-weight="700" letter-spacing="1">AWS</text>
+
+                    <!-- ════ DEV App Runner ════ -->
+                    <a href="https://ftngew3ms2.us-east-1.awsapprunner.com" target="_blank" class="app-link">
+                        <rect x="70"  y="28" width="180" height="118" rx="7" fill="url(#gradDev)"     stroke="#e2e8f0" stroke-width="1.5" filter="url(#cardShadow)"/>
+                        <rect x="82"  y="40"  width="36" height="17" rx="8" fill="#d1fae5"/>
+                        <text x="100" y="53"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" font-weight="700" fill="#065f46" text-anchor="middle">DEV</text>
+                        <text x="84"  y="78"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#1a202c">AWS App Runner</text>
+                        <text x="84"  y="95"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" fill="#718096">Flask Application</text>
+                        <rect x="82"  y="105" width="92" height="16" rx="8" fill="#dbeafe"/>
+                        <text x="128" y="117" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="9.5" font-weight="600" fill="#1d4ed8" text-anchor="middle">Docker Container</text>
+                        <rect x="70"  y="28" width="180" height="118" rx="7" class="hover-overlay"/>
+                    </a>
+
+                    <!-- ════ TEST App Runner ════ -->
+                    <a href="https://idimzicn3r.us-east-1.awsapprunner.com" target="_blank" class="app-link">
+                        <rect x="270" y="28" width="180" height="118" rx="7" fill="url(#gradTest)"    stroke="#e2e8f0" stroke-width="1.5" filter="url(#cardShadow)"/>
+                        <rect x="282" y="40"  width="40" height="17" rx="8" fill="#dbeafe"/>
+                        <text x="302" y="53"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" font-weight="700" fill="#1e40af" text-anchor="middle">TEST</text>
+                        <text x="284" y="78"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#1a202c">AWS App Runner</text>
+                        <text x="284" y="95"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" fill="#718096">Flask Application</text>
+                        <rect x="282" y="105" width="92" height="16" rx="8" fill="#dbeafe"/>
+                        <text x="328" y="117" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="9.5" font-weight="600" fill="#1d4ed8" text-anchor="middle">Docker Container</text>
+                        <rect x="270" y="28" width="180" height="118" rx="7" class="hover-overlay"/>
+                    </a>
+
+                    <!-- ════ STAGING App Runner ════ -->
+                    <a href="https://kyhmqghxzr.us-east-1.awsapprunner.com" target="_blank" class="app-link">
+                        <rect x="470" y="28" width="180" height="118" rx="7" fill="url(#gradStaging)" stroke="#e2e8f0" stroke-width="1.5" filter="url(#cardShadow)"/>
+                        <rect x="482" y="40"  width="55" height="17" rx="8" fill="#fef3c7"/>
+                        <text x="510" y="53"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" font-weight="700" fill="#92400e" text-anchor="middle">STAGING</text>
+                        <text x="484" y="78"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#1a202c">AWS App Runner</text>
+                        <text x="484" y="95"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" fill="#718096">Flask Application</text>
+                        <rect x="482" y="105" width="92" height="16" rx="8" fill="#dbeafe"/>
+                        <text x="528" y="117" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="9.5" font-weight="600" fill="#1d4ed8" text-anchor="middle">Docker Container</text>
+                        <rect x="470" y="28" width="180" height="118" rx="7" class="hover-overlay"/>
+                    </a>
+
+                    <!-- ════ PROD App Runner ════ -->
+                    <a href="https://cipykp34zu.us-east-1.awsapprunner.com" target="_blank" class="app-link">
+                        <rect x="670" y="28" width="180" height="118" rx="7" fill="url(#gradProd)"    stroke="#e2e8f0" stroke-width="1.5" filter="url(#cardShadow)"/>
+                        <rect x="682" y="40"  width="42" height="17" rx="8" fill="#fee2e2"/>
+                        <text x="703" y="53"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" font-weight="700" fill="#991b1b" text-anchor="middle">PROD</text>
+                        <text x="684" y="78"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="12" font-weight="700" fill="#1a202c">AWS App Runner</text>
+                        <text x="684" y="95"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" fill="#718096">Flask Application</text>
+                        <rect x="682" y="105" width="92" height="16" rx="8" fill="#dbeafe"/>
+                        <text x="728" y="117" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="9.5" font-weight="600" fill="#1d4ed8" text-anchor="middle">Docker Container</text>
+                        <rect x="670" y="28" width="180" height="118" rx="7" class="hover-overlay"/>
+                    </a>
+
+                    <!-- Lines from boxes down to collection line -->
+                    <line x1="160" y1="146" x2="160" y2="188" stroke="#94a3b8" stroke-width="1.5"/>
+                    <line x1="360" y1="146" x2="360" y2="188" stroke="#94a3b8" stroke-width="1.5"/>
+                    <line x1="560" y1="146" x2="560" y2="188" stroke="#94a3b8" stroke-width="1.5"/>
+                    <line x1="760" y1="146" x2="760" y2="188" stroke="#94a3b8" stroke-width="1.5"/>
+                    <!-- Horizontal collection line -->
+                    <line x1="160" y1="188" x2="760" y2="188" stroke="#cbd5e0" stroke-width="1.5"/>
+                    <!-- Dots at junctions -->
+                    <circle cx="160" cy="188" r="3" fill="#94a3b8"/>
+                    <circle cx="360" cy="188" r="3" fill="#94a3b8"/>
+                    <circle cx="560" cy="188" r="3" fill="#94a3b8"/>
+                    <circle cx="760" cy="188" r="3" fill="#94a3b8"/>
+
+                    <!-- Arrow: collection line → RDS -->
+                    <line x1="460" y1="188" x2="460" y2="212" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"/>
+                    <text x="466" y="205"  font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="9.5" fill="#94a3b8">psycopg2 / SQLAlchemy</text>
+
+                    <!-- ════ RDS BOX ════ -->
+                    <rect x="310" y="214" width="300" height="82" rx="7" fill="white" stroke="#bfdbfe" stroke-width="1.5" filter="url(#cardShadow)"/>
+                    <!-- Blue top accent -->
+                    <rect x="310" y="214" width="300" height="7"  rx="7" fill="#336791"/>
+                    <rect x="310" y="218"  width="300" height="3"  fill="#336791"/>
+                    <!-- Cylinder icon -->
+                    <ellipse cx="344" cy="244" rx="15" ry="5.5" fill="#336791" opacity="0.15"/>
+                    <rect    x="329"  y="244" width="30"  height="17"   fill="#336791" opacity="0.10"/>
+                    <ellipse cx="344" cy="261" rx="15" ry="5.5" fill="#336791" opacity="0.18"/>
+                    <ellipse cx="344" cy="244" rx="15" ry="5.5" fill="#336791" opacity="0.45"/>
+                    <!-- Text -->
+                    <text x="372" y="244" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="13" font-weight="700" fill="#1a202c">AWS RDS PostgreSQL</text>
+                    <text x="372" y="262" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="11" fill="#718096">Shared instance · 4 databases</text>
+                    <text x="372" y="278" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="10" fill="#94a3b8">dev · test · staging · prod</text>
+                </svg>
+            </div>
+
             <!-- Application URLs -->
             <div class="card">
                 <h2><span class="icon">🌐</span> Application URLs</h2>
@@ -299,8 +430,7 @@
                 <a href="https://s3.console.aws.amazon.com/s3/buckets/bagel-store-psr-liquibase-flows?region=us-east-1"
                    class="btn btn-secondary" target="_blank">Flows Bucket</a>
             </div>
-            
-            
+
             <!-- Demo Workflow -->
             <div class="card full-width">
                 <h2><span class="icon">🎬</span> Demo Workflow</h2>

--- a/harness/pipelines/deploy-pipeline.yaml
+++ b/harness/pipelines/deploy-pipeline.yaml
@@ -29,6 +29,18 @@ pipeline:
       required: true
       value: <+input>
 
+    - name: ROLLBACK
+      type: String
+      description: Set to "true" to rollback instead of deploy. Run a single stage only.
+      required: true
+      value: "false"
+
+    - name: ROLLBACK_TO_VERSION
+      type: String
+      description: Version to rollback to. Defaults to last successfully deployed version.
+      required: false
+      value: <+rollbackArtifact.tag>
+
   # Deployment stages for all four environments
   stages:
     # ===== STAGE 1: Deploy to Dev (Automatic) =====

--- a/harness/scripts/README.md
+++ b/harness/scripts/README.md
@@ -153,7 +153,83 @@ health-check.sh <ENVIRONMENT> <VERSION> <DEPLOYMENT_TARGET> <SERVICE_URL>
 
 ---
 
-### 5. `fetch-instances.sh`
+### 5. `rollback-database.sh`
+Rolls back database changes to a specific tagged version using the Liquibase rollback flow file.
+
+**Usage:**
+```bash
+rollback-database.sh <ENVIRONMENT> <DEMO_ID> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON> <ROLLBACK_TAG>
+```
+
+**Arguments:**
+- `ENVIRONMENT` - Target environment (dev/test/staging/prod)
+- `DEMO_ID` - Demo instance identifier
+- `DEPLOYMENT_TARGET` - Deployment mode: "aws" or "local"
+- `AWS_PARAMS_JSON` - JSON with AWS parameters (for AWS mode)
+- `SECRETS_JSON` - JSON with secret references
+- `ROLLBACK_TAG` - Liquibase tag to rollback to (e.g., v1.0.0)
+
+**AWS Mode:**
+- Uses S3 rollback flow file (verify → history → rollback)
+- Connects to RDS PostgreSQL
+- Uses AWS Secrets Manager for credentials
+
+**Local Mode:**
+- Uses local rollback flow file
+- Connects to Docker Compose postgres container
+- Uses hardcoded postgres/postgres credentials
+
+**Example (AWS):**
+```bash
+/opt/harness-delegate/scripts/rollback-database.sh \
+  "dev" \
+  "demo1" \
+  "aws" \
+  '{"jdbc_url":"jdbc:postgresql://...","aws_region":"us-east-1","liquibase_flows_bucket":"...","rds_endpoint":"..."}' \
+  '{"liquibase_license_key":"..."}' \
+  "v1.0.0"
+```
+
+---
+
+### 6. `rollback-application.sh`
+Rolls back application to a previous version by updating the service to use the target version's Docker image.
+
+**Usage:**
+```bash
+rollback-application.sh <ENVIRONMENT> <ROLLBACK_TO_VERSION> <GITHUB_ORG> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON>
+```
+
+**Arguments:**
+- `ENVIRONMENT` - Target environment (dev/test/staging/prod)
+- `ROLLBACK_TO_VERSION` - Version to rollback to (e.g., v1.0.0)
+- `GITHUB_ORG` - GitHub organization name
+- `DEPLOYMENT_TARGET` - Deployment mode: "aws" or "local"
+- `AWS_PARAMS_JSON` - JSON with AWS parameters
+- `SECRETS_JSON` - JSON with secret references
+
+**AWS Mode:**
+- Updates App Runner service with rollback version Docker image
+- Uses IAM instance profile for AWS authentication
+
+**Local Mode:**
+- Updates `.env` file with rollback version
+- Pulls rollback image and restarts Docker Compose service
+
+**Example (AWS):**
+```bash
+/opt/harness-delegate/scripts/rollback-application.sh \
+  "dev" \
+  "v1.0.0" \
+  "liquibase-examples" \
+  "aws" \
+  '{"app_runner_service_arn":"...","aws_region":"us-east-1","demo_id":"demo1",...}' \
+  '{}'
+```
+
+---
+
+### 7. `fetch-instances.sh`
 Reports instance information to Harness for deployment tracking.
 
 **Usage:**

--- a/harness/scripts/rollback-application.sh
+++ b/harness/scripts/rollback-application.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Rollback Application
+#
+# Rolls back the application to a previous version by updating the service
+# to use the target version's Docker image. Mirrors deploy-application.sh
+# structure for AWS (App Runner) and local (Docker Compose) modes.
+#
+# Usage:
+#   rollback-application.sh <ENVIRONMENT> <ROLLBACK_TO_VERSION> <GITHUB_ORG> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON>
+#
+# Arguments:
+#   ENVIRONMENT          - Target environment (dev/test/staging/prod)
+#   ROLLBACK_TO_VERSION  - Version to rollback to (e.g., v1.0.0)
+#   GITHUB_ORG           - GitHub organization name
+#   DEPLOYMENT_TARGET    - Deployment mode: "aws" or "local"
+#   AWS_PARAMS_JSON      - JSON with AWS parameters (for AWS mode)
+#   SECRETS_JSON         - JSON with secret references (for AWS mode)
+#
+# Exit Codes:
+#   0 - Success
+#   1 - Rollback failed or invalid arguments
+
+set -e
+
+# ===== Argument Parsing =====
+if [ $# -ne 6 ]; then
+  echo "Usage: $0 <ENVIRONMENT> <ROLLBACK_TO_VERSION> <GITHUB_ORG> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON>"
+  echo "Example: $0 dev v1.0.0 liquibase-examples aws '{...}' '{...}'"
+  exit 1
+fi
+
+ENVIRONMENT="$1"
+ROLLBACK_TO_VERSION="$2"
+GITHUB_ORG="$3"
+DEPLOYMENT_TARGET="$4"
+AWS_PARAMS_JSON="$5"
+SECRETS_JSON="$6"
+
+# ===== Validation =====
+if [ -z "${ROLLBACK_TO_VERSION}" ]; then
+  echo "ERROR: ROLLBACK_TO_VERSION is required but was empty"
+  echo "Provide the version to rollback to (e.g., v1.0.0)"
+  exit 1
+fi
+
+# ===== Main Logic =====
+echo "=== Rolling Back Application ==="
+echo "Environment: ${ENVIRONMENT}"
+echo "Rollback to Version: ${ROLLBACK_TO_VERSION}"
+echo "Deployment Target: ${DEPLOYMENT_TARGET}"
+
+if [ "$DEPLOYMENT_TARGET" = "aws" ]; then
+  # ===== AWS MODE - App Runner =====
+
+  # Extract AWS parameters
+  SERVICE_ARN=$(echo "$AWS_PARAMS_JSON" | jq -r '.app_runner_service_arn')
+  AWS_REGION=$(echo "$AWS_PARAMS_JSON" | jq -r '.aws_region')
+  DEMO_ID=$(echo "$AWS_PARAMS_JSON" | jq -r '.demo_id')
+  RDS_ADDRESS=$(echo "$AWS_PARAMS_JSON" | jq -r '.rds_address')
+  RDS_PORT=$(echo "$AWS_PARAMS_JSON" | jq -r '.rds_port')
+  DATABASE_NAME=$(echo "$AWS_PARAMS_JSON" | jq -r '.database_name')
+
+  echo "Rolling back App Runner service: ${SERVICE_ARN}"
+  echo "AWS authentication: IAM instance profile (EC2 delegate)"
+
+  export AWS_DEFAULT_REGION="${AWS_REGION}"
+
+  # Get Secrets Manager ARNs from AWS parameters
+  SECRETS_USERNAME_ARN=$(echo "$AWS_PARAMS_JSON" | jq -r '.secrets_username_arn')
+  SECRETS_PASSWORD_ARN=$(echo "$AWS_PARAMS_JSON" | jq -r '.secrets_password_arn')
+
+  # Extract ECR alias from AWS parameters
+  ECR_ALIAS=$(echo "$AWS_PARAMS_JSON" | jq -r '.ecr_public_alias')
+  IMAGE_URL="public.ecr.aws/${ECR_ALIAS}/${DEMO_ID}-bagel-store:${ROLLBACK_TO_VERSION}"
+
+  echo "Rolling back to Docker image: ${IMAGE_URL}"
+  echo "Using AWS Secrets Manager for database credentials (native App Runner integration)"
+
+  # Get current service configuration
+  echo "Fetching current service configuration..."
+  CURRENT_CONFIG=$(aws apprunner describe-service \
+    --service-arn "${SERVICE_ARN}" \
+    --region "${AWS_REGION}" \
+    --query 'Service.SourceConfiguration' \
+    --output json)
+
+  # Extract current configuration values to preserve
+  AUTO_DEPLOYMENTS=$(echo "$CURRENT_CONFIG" | jq -r '.AutoDeploymentsEnabled')
+
+  # Update App Runner service with rollback version image
+  echo "Updating App Runner service with rollback image..."
+  aws apprunner update-service \
+    --service-arn "${SERVICE_ARN}" \
+    --source-configuration "{
+      \"AutoDeploymentsEnabled\": ${AUTO_DEPLOYMENTS},
+      \"ImageRepository\": {
+        \"ImageIdentifier\": \"${IMAGE_URL}\",
+        \"ImageRepositoryType\": \"ECR_PUBLIC\",
+        \"ImageConfiguration\": {
+          \"Port\": \"5000\",
+          \"RuntimeEnvironmentVariables\": {
+            \"FLASK_ENV\": \"production\",
+            \"APP_VERSION\": \"${ROLLBACK_TO_VERSION}\",
+            \"DB_HOST\": \"${RDS_ADDRESS}\",
+            \"DB_PORT\": \"${RDS_PORT}\",
+            \"DB_NAME\": \"${DATABASE_NAME}\",
+            \"DEMO_ID\": \"${DEMO_ID}\",
+            \"DEMO_USERNAME\": \"demo\",
+            \"DEMO_PASSWORD\": \"bagels123\"
+          },
+          \"RuntimeEnvironmentSecrets\": {
+            \"DB_USERNAME\": \"${SECRETS_USERNAME_ARN}\",
+            \"DB_PASSWORD\": \"${SECRETS_PASSWORD_ARN}\"
+          }
+        }
+      }
+    }" \
+    --region "${AWS_REGION}"
+
+  echo "✅ App Runner service rollback initiated"
+
+else
+  # ===== LOCAL MODE - Docker Compose =====
+
+  echo "Rolling back Docker Compose service"
+
+  # Navigate to repository root
+  REPO_ROOT="$HOME/workspace/harness-gha-bagelstore"
+  cd "${REPO_ROOT}"
+
+  # Ensure .env file exists
+  if [ ! -f .env ]; then
+    echo "Creating .env from template"
+    cp .env.example .env
+  fi
+
+  # Update version in .env file
+  ENV_UPPER=$(echo "${ENVIRONMENT}" | tr '[:lower:]' '[:upper:]')
+  ENV_VAR="VERSION_${ENV_UPPER}"
+
+  echo "Updating ${ENV_VAR}=${ROLLBACK_TO_VERSION} in .env"
+
+  if grep -q "^${ENV_VAR}=" .env; then
+    # Update existing line (macOS compatible)
+    sed -i.bak "s/^${ENV_VAR}=.*/${ENV_VAR}=${ROLLBACK_TO_VERSION}/" .env
+    rm -f .env.bak
+  else
+    # Add new line
+    echo "${ENV_VAR}=${ROLLBACK_TO_VERSION}" >> .env
+  fi
+
+  # Show current .env state
+  echo "Current .env configuration:"
+  grep "^VERSION_" .env || echo "No VERSION variables found"
+
+  # Pull rollback image version
+  docker compose -f docker-compose-demo.yml pull "app-${ENVIRONMENT}"
+
+  # Restart specific service with rollback version
+  docker compose -f docker-compose-demo.yml up -d --no-deps "app-${ENVIRONMENT}"
+
+  echo "✅ Docker Compose service rolled back"
+fi
+
+echo "✅ Application rollback to version '${ROLLBACK_TO_VERSION}' completed"

--- a/harness/scripts/rollback-database.sh
+++ b/harness/scripts/rollback-database.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Rollback Database with Liquibase
+#
+# Rolls back database changes to a specific tagged version using the rollback
+# flow file. Mirrors update-database.sh structure for AWS and local modes.
+#
+# Usage:
+#   rollback-database.sh <ENVIRONMENT> <DEMO_ID> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON> <ROLLBACK_TAG>
+#
+# Arguments:
+#   ENVIRONMENT        - Target environment (dev/test/staging/prod)
+#   DEMO_ID            - Demo instance identifier
+#   DEPLOYMENT_TARGET  - Deployment mode: "aws" or "local"
+#   AWS_PARAMS_JSON    - JSON with AWS parameters (for AWS mode)
+#   SECRETS_JSON       - JSON with secret references (license, credentials)
+#   ROLLBACK_TAG       - Liquibase tag to rollback to (e.g., v1.0.0)
+#
+# Exit Codes:
+#   0 - Success
+#   1 - Rollback failed or invalid arguments
+
+set -e
+
+# ===== Argument Parsing =====
+if [ $# -ne 6 ]; then
+  echo "Usage: $0 <ENVIRONMENT> <DEMO_ID> <DEPLOYMENT_TARGET> <AWS_PARAMS_JSON> <SECRETS_JSON> <ROLLBACK_TAG>"
+  echo "Example: $0 dev demo1 aws '{...}' '{...}' v1.0.0"
+  exit 1
+fi
+
+ENVIRONMENT="$1"
+DEMO_ID="$2"
+DEPLOYMENT_TARGET="$3"
+AWS_PARAMS_JSON="$4"
+SECRETS_JSON="$5"
+ROLLBACK_TAG="$6"
+
+# ===== Validation =====
+if [ -z "${ROLLBACK_TAG}" ]; then
+  echo "ERROR: ROLLBACK_TAG is required but was empty"
+  echo "Provide the version tag to rollback to (e.g., v1.0.0)"
+  exit 1
+fi
+
+# ===== Configuration =====
+VOLUME_NAME="harness-changelog-data"
+LIQUIBASE_VERSION="5.0.1"
+
+# ===== Main Logic =====
+echo "=== Rolling Back Database with Liquibase ==="
+echo "Environment: ${ENVIRONMENT}"
+echo "Demo ID: ${DEMO_ID}"
+echo "Deployment Target: ${DEPLOYMENT_TARGET}"
+echo "Rollback Tag: ${ROLLBACK_TAG}"
+
+if [ "$DEPLOYMENT_TARGET" = "aws" ]; then
+  # ===== AWS MODE - Use S3 Rollback Flow File =====
+
+  # DEBUG: Show received JSON
+  echo "DEBUG: AWS_PARAMS_JSON received:"
+  echo "$AWS_PARAMS_JSON"
+  echo ""
+  echo "DEBUG: SECRETS_JSON received:"
+  echo "$SECRETS_JSON" | sed 's/\(license_key\)":\s*"[^"]*"/\1":"***REDACTED***"/g'
+  echo ""
+
+  # Extract AWS parameters
+  JDBC_URL=$(echo "$AWS_PARAMS_JSON" | jq -r '.jdbc_url')
+  AWS_REGION=$(echo "$AWS_PARAMS_JSON" | jq -r '.aws_region')
+  FLOWS_BUCKET=$(echo "$AWS_PARAMS_JSON" | jq -r '.liquibase_flows_bucket')
+  RDS_ENDPOINT=$(echo "$AWS_PARAMS_JSON" | jq -r '.rds_endpoint')
+
+  # Extract secrets
+  LIQUIBASE_LICENSE_KEY=$(echo "$SECRETS_JSON" | jq -r '.liquibase_license_key')
+
+  echo "Using AWS RDS endpoint: ${RDS_ENDPOINT}"
+  echo "Rollback flow file: s3://${FLOWS_BUCKET}/rollback-flow.yaml"
+  echo "Database credentials: Liquibase native AWS Secrets Manager (JSON secret: ${DEMO_ID}/rds/credentials)"
+  echo "AWS authentication: IAM instance profile (EC2 delegate)"
+
+  docker run --rm \
+    -v "${VOLUME_NAME}:/liquibase/changelog" \
+    -e ROLLBACK_TAG="${ROLLBACK_TAG}" \
+    -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+    -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+    -e AWS_REGION="${AWS_REGION}" \
+    -e AWS_DEFAULT_REGION="${AWS_REGION}" \
+    -e LIQUIBASE_LICENSE_KEY="${LIQUIBASE_LICENSE_KEY}" \
+    -e LIQUIBASE_COMMAND_URL="${JDBC_URL}" \
+    -e LIQUIBASE_COMMAND_USERNAME="aws-secrets,${DEMO_ID}/rds/credentials,username" \
+    -e LIQUIBASE_COMMAND_PASSWORD="aws-secrets,${DEMO_ID}/rds/credentials,password" \
+    -e LIQUIBASE_COMMAND_CHANGELOG_FILE=changelog-master.yaml \
+    -w /liquibase/changelog \
+    "liquibase/liquibase-secure:${LIQUIBASE_VERSION}" \
+    flow \
+    --flow-file="s3://${FLOWS_BUCKET}/rollback-flow.yaml"
+
+else
+  # ===== LOCAL MODE - Use Local Rollback Flow File =====
+
+  # Extract secrets
+  LIQUIBASE_LICENSE_KEY=$(echo "$SECRETS_JSON" | jq -r '.liquibase_license_key')
+
+  echo "Using local PostgreSQL container: postgres-${ENVIRONMENT}"
+  echo "Using local rollback flow file"
+
+  # Determine the repo root for mounting flow files
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+  docker run --rm \
+    --network harness-gha-bagelstore_bagel-network \
+    -v "${VOLUME_NAME}:/liquibase/changelog" \
+    -v "${REPO_ROOT}/liquibase-flows:/liquibase/flows" \
+    -e ROLLBACK_TAG="${ROLLBACK_TAG}" \
+    -e LIQUIBASE_LICENSE_KEY="${LIQUIBASE_LICENSE_KEY}" \
+    -w /liquibase/changelog \
+    "liquibase/liquibase-secure:${LIQUIBASE_VERSION}" \
+    --url="jdbc:postgresql://postgres-${ENVIRONMENT}:5432/${ENVIRONMENT}" \
+    --username=postgres \
+    --password=postgres \
+    --changeLogFile=changelog-master.yaml \
+    --log-level=INFO \
+    flow \
+    --flow-file=/liquibase/flows/rollback-flow.yaml
+fi
+
+echo "✅ Database rollback to tag '${ROLLBACK_TAG}' completed successfully"

--- a/liquibase-flows/README.md
+++ b/liquibase-flows/README.md
@@ -8,6 +8,7 @@ Liquibase flow files and policy checks configuration for the Bagel Store demo. T
 
 - **[pr-validation-flow.yaml](pr-validation-flow.yaml)** - Pull request validation flow
 - **[main-deployment-flow.yaml](main-deployment-flow.yaml)** - Main branch deployment flow
+- **[rollback-flow.yaml](rollback-flow.yaml)** - Database rollback flow (rollback to tagged version)
 
 ### Configuration
 
@@ -215,6 +216,16 @@ resource "aws_s3_object" "policy_checks_config" {
 - `REPORTS_PATH: "reports"`
 - `VERSION: "${VERSION:-latest}"`
 - Artifact naming: `bagel-store-changelog-${VERSION}.zip`
+
+### rollback-flow.yaml
+- `ENV: "ROLLBACK"`
+- `REPORTS_PATH: "reports"`
+- `ROLLBACK_TAG: "${ROLLBACK_TAG:-REQUIRED}"` - Must be set via `-e ROLLBACK_TAG=...`
+
+### Rollback Reports
+- `rollback-connection-report.html` - Database connection validation
+- `rollback-history-report.html` - Pre-rollback change history audit
+- `rollback-report.html` - Rollback operation results
 
 ## Exit Codes
 

--- a/liquibase-flows/rollback-flow.yaml
+++ b/liquibase-flows/rollback-flow.yaml
@@ -1,0 +1,86 @@
+##########           LIQUIBASE FLOWFILE                ##########
+##########  learn more http://docs.liquibase.com/flow  ##########
+##
+## Rollback Flow
+## Purpose: Roll back database changes to a specific tagged version
+## Pattern: Verify connectivity, show history for audit, then rollback to tag
+##
+## Usage:
+##   Pass ROLLBACK_TAG as an environment variable to the Docker container:
+##     docker run -e ROLLBACK_TAG="v1.0.0" ... liquibase/liquibase-secure:5.0.1 \
+##       flow --flow-file=rollback-flow.yaml
+##
+## Note: No policy checks stage — rollback undoes changes, doesn't apply new ones.
+##
+
+globalVariables:
+  ENV: "ROLLBACK"
+  REPORTS_PATH: "reports"
+  ROLLBACK_TAG: "${ROLLBACK_TAG:-REQUIRED}"
+  ROLLBACK_REPORT: "rollback-report.html"
+  CONNECTION_REPORT: "rollback-connection-report.html"
+  HISTORY_REPORT: "rollback-history-report.html"
+
+stages:
+  # Stage 1: Verify connectivity and changelog validity
+  Verify:
+    actions:
+      - type: liquibase
+        command: connect
+        globalArgs:
+          reports-enabled: "true"
+          reports-path: "${REPORTS_PATH}"
+          reports-name: "${CONNECTION_REPORT}"
+
+      - type: liquibase
+        command: validate
+        globalArgs:
+          reports-enabled: "true"
+          reports-path: "${REPORTS_PATH}"
+
+  # Stage 2: Show change history for audit trail before rollback
+  PreRollbackAudit:
+    actions:
+      - type: liquibase
+        command: history
+        globalArgs:
+          reports-enabled: "true"
+          reports-path: "${REPORTS_PATH}"
+          reports-name: "${HISTORY_REPORT}"
+
+      - type: shell
+        command: >
+          echo '========================================' &&
+          echo '  ROLLBACK TARGET: ${ROLLBACK_TAG}' &&
+          echo '  Will roll back all changes AFTER tag: ${ROLLBACK_TAG}' &&
+          echo '========================================'
+
+  # Stage 3: Execute rollback to the target tag
+  Rollback:
+    actions:
+      - type: liquibase
+        command: rollback
+        cmdArgs:
+          tag: "${ROLLBACK_TAG}"
+        globalArgs:
+          reports-enabled: "true"
+          reports-path: "${REPORTS_PATH}"
+          reports-name: "${ROLLBACK_REPORT}"
+          reports-open: "false"
+
+endStage:
+  actions:
+    - type: shell
+      command: >
+        echo '========================================' &&
+        echo '   ROLLBACK SUMMARY' &&
+        echo '========================================' &&
+        echo 'Environment: ${ENV}' &&
+        echo 'Rolled back to tag: ${ROLLBACK_TAG}' &&
+        echo 'Reports Path: ${REPORTS_PATH}/' &&
+        echo '' &&
+        echo 'Generated Reports:' &&
+        (ls -lh '${REPORTS_PATH}/'*.html 2>/dev/null || echo '  No reports found') &&
+        echo '' &&
+        echo 'Rollback complete!' &&
+        echo '========================================'

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -81,6 +81,24 @@ resource "aws_s3_object" "main_deployment_flow" {
   )
 }
 
+resource "aws_s3_object" "rollback_flow" {
+  count = var.deployment_mode == "aws" ? 1 : 0
+
+  bucket = aws_s3_bucket.liquibase_flows[0].id
+  key    = "rollback-flow.yaml"
+  source = "${path.module}/../liquibase-flows/rollback-flow.yaml"
+  etag   = filemd5("${path.module}/../liquibase-flows/rollback-flow.yaml")
+
+  content_type = "application/x-yaml"
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "rollback-flow.yaml"
+    }
+  )
+}
+
 resource "aws_s3_object" "policy_checks_config" {
   count = var.deployment_mode == "aws" ? 1 : 0
 


### PR DESCRIPTION
## Summary
- Adds manual rollback support to the Deploy Bagel Store pipeline for CustomDeployment (which lacks Harness's built-in rollback button)
- Operator triggers rollback by re-running the pipeline for a single stage with `ROLLBACK=true` and `ROLLBACK_TO_VERSION` set to the target version
- New Liquibase rollback flow file (verify → history audit → rollback to tag) uploaded to S3 via Terraform
- Application rolls back before database to avoid new code running against old schema

## Test plan
- [ ] Run `terraform apply` to upload `rollback-flow.yaml` to S3
- [ ] Refresh `Coordinated_DB_App_Deployment` template in Harness UI after merge
- [ ] Restart delegate: `cd harness && docker compose restart`
- [ ] Test normal deploy: Run pipeline with defaults → steps 1-5 execute, steps 6-9 skip
- [ ] Test rollback: Run pipeline for single stage with `ROLLBACK=true`, `ROLLBACK_TO_VERSION=<version>` → steps 1-5 skip, steps 6-9 execute
- [ ] Verify webhook triggers still work (ROLLBACK defaults to "false" in input set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)